### PR TITLE
Remove Locale Settings

### DIFF
--- a/usr/lib/zabbix/externalscripts/ssltls.check
+++ b/usr/lib/zabbix/externalscripts/ssltls.check
@@ -120,8 +120,6 @@ if [ $# -ne 3 ]; then
  exit 1
 fi
 
-LOC="en_GB.UTF8"
-export LC_ALL=$LOC
 
 # assign arguments to variables
 #


### PR DESCRIPTION
Throws Error on Systems with no Locale Set.